### PR TITLE
Allow customisation of the code block language

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,11 @@ Configure this plugin:
 
 Details of configuration options:
 
-|    Name     |     Values     |               Default               |                     Description                      |
-| :---------: | :------------: | :---------------------------------: | :--------------------------------------------------: |
-| `imageType` | `svg` or `png` |                `svg`                |   Type of PlantUML image returned from Web Server.   |
-|  `server`   |  url (string)  | `https://www.plantuml.com/plantuml` | PlantUML server to generate UML diagrams on-the-fly. |
+|      Name       |     Values     |               Default               |                     Description                      |
+| :-------------: | :------------: | :---------------------------------: | :--------------------------------------------------: |
+|   `imageType`   | `svg` or `png` |                `svg`                |   Type of PlantUML image returned from Web Server.   |
+|     `server`    |  url (string)  | `https://www.plantuml.com/plantuml` | PlantUML server to generate UML diagrams on-the-fly. |
+| `codeBlockLang` |  name (string) |              `plantuml`             |             Name of the codeblock languange.         |
 
 ### Use in Markdown
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,5 +1,8 @@
 exports.pluginOptionsSchema = ({ Joi }) => {
   return Joi.object({
+    codeBlockLang: Joi.string()
+      .default("plantuml")
+      .description("Name of the codeblock languange."),
     imageType: Joi.string()
       .default("svg")
       .description("Type of PlantUML image returned from Web Server."),

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ interface ParsedTypes {
 interface OptionTypes {
   imageType?: "svg" | "png",
   server?: string,
+  codeBlockLang?: string,
 }
 
 export default function remarkPlantUML({ markdownAST }: ParsedTypes, pluginOptions?: OptionTypes) {
@@ -19,9 +20,12 @@ export default function remarkPlantUML({ markdownAST }: ParsedTypes, pluginOptio
       ? pluginOptions.server.substr(0, pluginOptions.server.length - 1)
       : pluginOptions.server
     : "https://www.plantuml.com/plantuml"
+  const codeBlockLang = pluginOptions?.codeBlockLang
+    ? pluginOptions.codeBlockLang
+    : "plantuml";
   return nodeOperator(markdownAST, (encoded) => {
     return `${server}/${imageType}/${encoded}`
-  })
+  }, codeBlockLang)
 }
 
 module.exports = remarkPlantUML

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -2,9 +2,9 @@ import plantUMLEncoder = require("plantuml-encoder")
 import flatmap = require("unist-util-flatmap")
 import { Node } from "unist"
 
-export default function nodeOperator(node: Node, fn: (encoded: string) => string) {
+export default function nodeOperator(node: Node, fn: (encoded: string) => string, codeBlockName: string = "plantuml") {
   return flatmap(node, (node) => {
-    return node.type === "code" && node.lang === "plantuml"
+    return node.type === "code" && node.lang === codeBlockName
       ? [{
         type: "paragraph",
         children: [{

--- a/tests/examples/test.data.5.json
+++ b/tests/examples/test.data.5.json
@@ -1,0 +1,40 @@
+{
+  "children": [
+    {
+      "children": [
+        {
+          "alt": "PlantUML",
+          "position": {
+            "end": {
+              "column": 6,
+              "line": 6,
+              "offset": 59
+            },
+            "start": {
+              "column": 3,
+              "line": 2,
+              "offset": 3
+            }
+          },
+          "title": null,
+          "type": "image",
+          "url": "https://www.plantuml.com/plantuml/svg/SoWkIImgAStDuN9KqBLJSB9Iy4ZDoSbNq5TuidV1qwLxrRaSKlDIWF80"
+        }
+      ],
+      "type": "paragraph"
+    }
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 7,
+      "offset": 62
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0
+    }
+  },
+  "type": "root"
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -65,3 +65,16 @@ test("测试默认配置选项", () => {
   const result = remarkPlantUML({ markdownAST: raw })
   expect(result).toStrictEqual(example)
 })
+
+test("测试默认配置选项", () => {
+  const raw = remark().parse(`
+  \`\`\`uml
+  @startuml
+  A -> B: Hello / 你好'
+  @enduml
+  \`\`\`
+  `)
+  const example = require("./examples/test.data.5.json")
+  const result = remarkPlantUML({ markdownAST: raw }, { codeBlockLang: "uml" })
+  expect(result).toStrictEqual(example)
+})


### PR DESCRIPTION
This change allows the configuration of the name which is used to identify the plantuml code blocks. We need this, because we have a lot of documents which are using `uml` instead of `plantuml`.